### PR TITLE
Update shutdown sequence.

### DIFF
--- a/boardfunctions.py
+++ b/boardfunctions.py
@@ -380,7 +380,18 @@ def rotateFieldHex(fieldHex):
 
 def convertField(field):
     square = chr((ord('a') + (field % 8))) + chr(ord('1') + (field // 8))
-    return square
+    return squar:wqe
+
+def shutdown():
+    """
+    Initiate shutdown sequence.
+    """
+    initScreen()
+    clearScreenBuffer()
+    sleepScreen()
+    tosend = bytearray(b'\xb2\x00\x07\x06\x50\x0a\x19')
+    ser.write(tosend)
+
 
 
 # poll()

--- a/boardfunctions.py
+++ b/boardfunctions.py
@@ -380,7 +380,7 @@ def rotateFieldHex(fieldHex):
 
 def convertField(field):
     square = chr((ord('a') + (field % 8))) + chr(ord('1') + (field // 8))
-    return squar:wqe
+    return square
 
 def shutdown():
     """

--- a/menu.py
+++ b/menu.py
@@ -26,11 +26,8 @@ while True:
         os.system("/home/pi/centaur/centaur")
         sys.exit()
     if result == "Shutdown":
-        boardfunctions.clearScreen()
-        boardfunctions.sleepScreen()
         boardfunctions.beep(boardfunctions.SOUND_POWER_OFF)
-        os.system("/sbin/shutdown now")
-        sys.exit()
+        boardfunctions.shutdown()
     if result == "Reboot":
         boardfunctions.clearScreen()
         boardfunctions.sleepScreen()
@@ -38,12 +35,8 @@ while True:
         os.system("/sbin/shutdown -r now")
         sys.exit()
     if result == "BACK":
-        boardfunctions.clearScreen()
-        boardfunctions.sleepScreen()
         boardfunctions.beep(boardfunctions.SOUND_POWER_OFF)
-        os.system("/sbin/shutdown now")
-        sys.exit()
-
+        boardfunctions.shutdown()
     if result == "Lichess":
         lichessmenu = {'Current': 'Current', 'New': 'New Game'}
         result = boardfunctions.doMenu(lichessmenu)


### PR DESCRIPTION
If RPi board is turned off by normal shutdown command, the controller remains on and needs to be hard turned off by holding Play/Pause button for a long time. And then you can turn on the board again. This happens if you want to power on the board right after shutdown, Looks like the controller has a timeout feature and it will power off in the end so this behaviour won't happen after few hours....

So, this change will turn off Centaur controller as well not just the RPi board. The serial commad will initiate the shutdown of the controller and it will cut the power to the RPi in 10 seconds. There is no way to prevent this hard power off.

In the future, I am thinking of having this procedure in the systemd service and execute is right at the end when the system shuts down,