### PR TITLE
Add python environment.

### DIFF
--- a/dgt_centaur_mods/board/boardfunctions.py
+++ b/dgt_centaur_mods/board/boardfunctions.py
@@ -14,7 +14,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 # Open the serial port, baudrate is 1000000
 ser = serial.Serial("/dev/ttyS0", baudrate=1000000, timeout=0.2)
-font18 = ImageFont.truetype("/home/pi/mods/resources/Font.ttc", 18)
+font18 = ImageFont.truetype("dgt_centaur_mods/resources/Font.ttc", 18)
 screenbuffer = Image.new('1', (128, 296), 255)
 initialised = 0
 

--- a/dgt_centaur_mods/scripts/deploy-python-env.sh
+++ b/dgt_centaur_mods/scripts/deploy-python-env.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/sh
+
+# Check if pip is installed
+if sudo dpkg -l | grep -q python-pip
+then
+    echo "::: Pip is installed."
+else
+    echo "::: Pip not installed. Installing now..."
+    sudo apt-get install -y python-pip
+fi
+
+# Check if virtualenv is installe
+if sudo pip3 list | grep virtualenv
+then
+    echo "::: Virtualenv is installed."
+else
+   echo "::: Virtualenv missing, Installing..."
+   sudo pip3 inst5all virtualenv
+fi
+
+# Deploy python environment
+cd ../..
+echo "::: Deploying python env..."
+virtualenv .venv
+
+echo "::: Installing packages inside the environment..."
+./.venv/bin/pip3 install -r requirements.txt
+
+echo "::: All done."
+echo ":: Activate environment using \"source .venv/bin/activate\""
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Pillow==8.3.2
+pyserial==3.5
+RPi.GPIO==0.7.0
+spidev==3.5


### PR DESCRIPTION
This will ensure packages stay the same across all devs.

Created requirements.txt file with python packages and current version that are tested and work.
Added a script to deploy the environment and install the packages listed in requirements.txt inside the env.

```git pull
cd dgt_centaur_mods/scripts
./deploy-python-env.sh
```

To activate the environment and work inside:
Go to DGTCentaur
```source  .venv/bin/activate```
Check path to pytho3,7 is inside the .venv/bin with ```which python3.7```
Deactivate simply by issuing ```deactivate```

To call py scripts inside the environment without activating:
```./home/pi/DGTCentaur/.venv/bin/python3.7 menu.py```