### PR TITLE
Add systemd services.

### DIFF
--- a/DGTCentaurMods/game/menu.py
+++ b/DGTCentaurMods/game/menu.py
@@ -30,7 +30,10 @@ while True:
     if result == "Centaur":
         boardfunctions.clearScreen()
         os.chdir("/home/pi/centaur")
-        os.system("/home/pi/centaur/centaur")
+        os.system("sudo systemctl start centaur.service")
+        # Once started we cannot return to DGTCentaurMods, we can kill that
+        time.sleep(3)
+        os.system("sudo systemctl stop DGTCentaurMods.service")
         sys.exit()
     if result == "EmulateEB":
         boardfunctions.clearScreen()


### PR DESCRIPTION
Here are the services for systemd for both centaur and DGTCentaurMods.
You have to edit DGTCentaurMods.service to start menu.py in you location togheter with python executable: `python3.7 menu.py`

To install the services:
- copy files to /etc/systemd/system
- reload the systemd daemon: `sudo systemd daemon-reload`
- kill running menu.py started in rc.local and remove that line
- start DGTCentaurMods: `sudo systemctl start DGTCentaurMods.service`
- set autostart: `suso systemclt enable DGTCentaurMods.service`

I noticed that stopping the DGTCentaurMods will also preserve the logo on the screen once centaur software is tured off :))
For now it is a bit manual work but in the end, all these steps will be included in the install script that will handle the services deployment.

All set!