### PR TITLE
Do not show DGT Centaur menu item is software is missing.

### DIFF
--- a/DGTCentaurMods/game/menu.py
+++ b/DGTCentaurMods/game/menu.py
@@ -11,6 +11,7 @@ import threading
 menuitem = 1
 curmenu = None
 selection = ""
+centaur_software="/home/pi/centaur/centaur"
 
 event_key = threading.Event()
 
@@ -135,14 +136,23 @@ boardfunctions.subscribeEvents(keyPressed, fieldActivity)
 
 # Handle the menu structure
 while True:
-    menu = {
-        'Centaur': 'DGT Centaur',
-        'Lichess': 'Lichess',
-        'Engines' : 'Engines',
-        'EmulateEB': 'e-Board',
-        'Cast' : 'Chromecast',
-        'settings': 'Settings',
-        'Support': 'Get support'}
+    if not os.path.exists(centaur_software):
+        menu = { 
+            'Lichess': 'Lichess',
+            'Engines' : 'Engines',
+            'EmulateEB': 'e-Board',
+            'Cast' : 'Chromecast',
+            'settings': 'Settings',
+            'Support': 'Get support'}
+    else:
+        menu = {
+            'Centaur': 'DGT Centaur',
+            'Lichess': 'Lichess',
+            'Engines' : 'Engines',
+            'EmulateEB': 'e-Board',
+            'Cast' : 'Chromecast',
+            'settings': 'Settings',
+            'Support': 'Get support'}
     result = doMenu(menu)
     epaper.epd.init()
     time.sleep(0.2)


### PR DESCRIPTION
Just an idea I had since a long time so I took the time to complete the task.
Don't show "DGT Centaur" menu item if software is missing. We'll figure out a way to help user deploy this easily, maybe an OTA push with an option in the Settings and ask to user to agree an EULA since is not our software.

Probably most users will know how to copy from original card but some might not.

We should not publish DGT software here,