### PR TITLE
 check  libsqlite3-dev in build.sh , fix copy stockfish_pi and remove setup lichess in postinst 

### DIFF
--- a/DGTCentaurMods/config/centaur.ini
+++ b/DGTCentaurMods/config/centaur.ini
@@ -2,7 +2,7 @@
 database_uri = 
 
 [lichess]
-api_token = lip_mdksVVtONzf4OqdLgAZ3
+api_token = 
 range = 0-3000
 
 [sound]

--- a/build/build.sh
+++ b/build/build.sh
@@ -16,25 +16,29 @@ function build {
 }
 
 function insertStockfish {
-    if [ ! -d Stockfish ] 
+    if [ ! -f ./Stockfish/src/stockfish_pi ] 
     then
-
-        git clone $STOCKFISH_REPO
-
+        if [ ! -d Stockfish ]
+        then
+            git clone $STOCKFISH_REPO
+        fi
+        if [ $(dpkg-query -W -f='${Status}' libsqlite3-dev 2>/dev/null | grep -c "ok installed") -eq 0 ];
+        then
+            sudo apt-get install libsqlite3-dev;
+        fi
         cd Stockfish/src
-            make clean
-            #make map
-            make -j$(nproc) build ARCH=armv7
+        make clean
+        #make map
+        make -j$(nproc) build ARCH=armv7
 
-            mv stockfish stockfish_pi
-            cp stockfish_pi ${BASE}/${STAGE}/${SETUP_DIR}/${PCK_NAME}/engines
-        
+        mv stockfish stockfish_pi
+        cp stockfish_pi ${BASE}/${STAGE}/${SETUP_DIR}/${PCK_NAME}/engines
         cd $BASE
     else 
         read -p "DO you want to rebuild Stockfish (y/n):"
         case $REPLY in
         [Yy]* ) rm -rf Stockfish && insertStockfish;;
-        Nn]* )  cp stockfish_pi ${BASE}/${STAGE}/${SETUP_DIR}/${PCK_NAME}/engines && echo "::: Move on";;
+        Nn]* )  cp ./Stockfish/src/stockfish_pi ${BASE}/${STAGE}/${SETUP_DIR}/${PCK_NAME}/engines && echo "::: Move on";;
         esac  
         
     fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -37,7 +37,7 @@ function insertStockfish {
         read -p "DO you want to rebuild Stockfish (y/n):"
         case $REPLY in
         [Yy]* ) rm -rf Stockfish && insertStockfish;;
-        Nn]* )  cp ./Stockfish/src/stockfish_pi ${BASE}/${STAGE}/${SETUP_DIR}/${PCK_NAME}/engines && echo "::: Move on";;
+        [Nn]* )  cp ./Stockfish/src/stockfish_pi ${BASE}/${STAGE}/${SETUP_DIR}/${PCK_NAME}/engines && echo "::: Move on";;
         esac  
         
     fi
@@ -162,7 +162,7 @@ configSetup
 read -p "DO you want to integrate Stockfish for this build? (y/n):"
 case $REPLY in
     [Yy]* ) insertStockfish;;
-    Nn]* ) echo "::: Move on";;
+    [Nn]* ) echo "::: Move on";;
 esac
 
 

--- a/build/postinst
+++ b/build/postinst
@@ -1,7 +1,6 @@
 #!/usr/bin/bash
 
 #### HARDWARE CONFIGURATION
-STOCKFISH_VERSION="14"
 CURRHOSTNAME=`hostname`
 HOSTNAME="dgtcentaur"
 CONFIG="/boot/config.txt"
@@ -108,7 +107,6 @@ then
     then
         mv ${CENTAUR_ENGINE}/$STOCKFISH ${CENTAUR_ENGINE}/$STOCKFISH.bak
         mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE/$STOCKFISH
-        # mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE/stockfish_$STOCKFISH_VERSION
     else
         mkdir -p $CENTAUR_ENGINE
         mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE

--- a/build/postinst
+++ b/build/postinst
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 #### HARDWARE CONFIGURATION
+STOCKFISH_VERSION="14"
 CURRHOSTNAME=`hostname`
 HOSTNAME="dgtcentaur"
 CONFIG="/boot/config.txt"
@@ -95,8 +96,8 @@ if [[ -e ${SETUP_DIR}/engines/$STOCKFISH ]]
 then
     if [[ -d $CENTAUR_ENGINE ]]
     then
-        mv ${CENTAUR_ENGINE}/stockfish_pi ${CENTAUR_ENGINE}/stockfish_pi.bak
-        mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE
+#        mv ${CENTAUR_ENGINE}/stockfish_pi ${CENTAUR_ENGINE}/stockfish_pi.bak
+        mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE/stockfish_$STOCKFISH_VERSION
     else
         mkdir -p $CENTAUR_ENGINE
         mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE
@@ -195,15 +196,15 @@ chown -R pi.pi ${SETUP_DIR}
 
 
 # Setting up lichess key
-echo -e "\n\n"
-read -p "Do you have a Lichess API token? (y/n): "
-case $REPLY in
-    [Yy]* ) add_lichess_key;;
-    [Nn]* )
-        exit
-        ;;
-    * ) ;;
-esac
+#echo -e "\n\n"
+#read -p "Do you have a Lichess API token? (y/n): "
+#case $REPLY in
+#    [Yy]* ) add_lichess_key;;
+#    [Nn]* )
+#        exit
+#        ;;
+#    * ) ;;
+#esac
 
 update_hostname
 

--- a/build/postinst
+++ b/build/postinst
@@ -106,8 +106,9 @@ if [[ -e ${SETUP_DIR}/engines/$STOCKFISH ]]
 then
     if [[ -d $CENTAUR_ENGINE ]]
     then
-#        mv ${CENTAUR_ENGINE}/stockfish_pi ${CENTAUR_ENGINE}/stockfish_pi.bak
-        mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE/stockfish_$STOCKFISH_VERSION
+        mv ${CENTAUR_ENGINE}/$STOCKFISH ${CENTAUR_ENGINE}/$STOCKFISH.bak
+        mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE/$STOCKFISH
+        # mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE/stockfish_$STOCKFISH_VERSION
     else
         mkdir -p $CENTAUR_ENGINE
         mv ${SETUP_DIR}/engines/$STOCKFISH $CENTAUR_ENGINE


### PR DESCRIPTION
Add missing libs libsqlite3-dev to build.sh so that Stockfish can be built on a new image of Raspbian and correct script to add stockfish_pi from an already existing and previous Stockfish build.

Maybe I should check if sources from STOCKFISH_REPO are still up2date to decide if we still need to rebuild even when user selects not to rebuild.