### PR TITLE
Shutdown service

### DIFF
--- a/DGTCentaurMods/board/shutdown.py
+++ b/DGTCentaurMods/board/shutdown.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+from DGTCentaurMods.board import board
+
+import os
+import time
+
+#Make sure DGTM is stopped in case board is powered off by ssh
+os.system("sudo systemctl stop DGTCentaurMods")
+time.sleep(3)
+
+print("Sending shutdown request to the controller")
+board.shutdown()
+

--- a/DGTCentaurMods/game/menu.py
+++ b/DGTCentaurMods/game/menu.py
@@ -177,7 +177,6 @@ while True:
     time.sleep(1.5)
     if result == "BACK":
         board.beep(board.SOUND_POWER_OFF)
-        #oardfunctions.shutdown()
     if result == "Cast":
         epaper.clearScreen()
         epaper.writeText(0,"Loading...")
@@ -307,9 +306,9 @@ while True:
             epaper.epd.HalfClear()
             time.sleep(5)
             epaper.stopEpaper()
-            time.sleep(2)
+            os.system("sudo poweroff")
+            time.sleep(3)
             board.pauseEvents()
-            board.shutdown()
         if result == "Reboot":
             board.beep(board.SOUND_POWER_OFF)
             epaper.epd.init()

--- a/build/DEBIAN/postinst
+++ b/build/DEBIAN/postinst
@@ -78,6 +78,7 @@ echo -e "Services setup\n"
     systemctl enable ntp
     systemctl enable var-run-sdp.path
     systemctl enable var-run-sdp.service
+    systemctl enable stopDGTController.service
     systemctl start var-run-sdp.path
 
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -69,9 +69,7 @@ function insertStockfish {
 
 
 
-function configSetup {
-    sed -i "s/Version:.*/Version: $VERSION/g" DEBIAN/control
-    
+function configSetup {  
     cd ${STAGE}/etc/systemd/system
         local SETUP_DIR=$(sed 's/[^a-zA-Z0-9]/\\&/g' <<<"$SETUP_DIR")
         
@@ -86,13 +84,20 @@ function configSetup {
             sed -i "s/WorkingDirectory=.*/WorkingDirectory=${SETUP_DIR}\/${PCK_NAME}\/web/g" centaurmods-web.service
             sed -i "s/Environment=.*/Environment=\"PYTHONPATH=${SETUP_DIR}\"/g" centaurmods-web.service
         
+        echo "::: Configuring service: stopDGTController.service"
+	    sed -i "s/WorkingDirectory=.*/WorkingDirectory=${SETUP_DIR}\/${PCK_NAME}/g" stopDGTController.service
+	    sed -i "s/ExecStart=.*/ExecStart=python3 board\/shutdown.py/g" stopDGTController.service
+            sed -i "s/Environment=.*/Environment=\"PYTHONPATH=${SETUP_DIR}\"/g"	stopDGTController.service
+
     cd $BASE
-    # Setup postinst file
+    echo "Entrying folder $BASE"
+        cp -r DEBIAN ${STAGE}/
+    # Setup postinst and control file
+        sed -i "s/Version:.*/Version: $VERSION/g" ${STAGE}/DEBIAN/control
         echo "::: Configuring postinst."
-        sed -i "s/^SETUP_DIR.*/SETUP_DIR=\"${SETUP_DIR}\/${PCK_NAME}\"/g" DEBIAN/postinst
-        sed -i "s/^CENTAURINI.*/CENTAURINI=${SETUP_DIR}\/${PCK_NAME}\/config\/centaur.ini/g" DEBIAN/postinst
+        sed -i "s/^SETUP_DIR.*/SETUP_DIR=\"${SETUP_DIR}\/${PCK_NAME}\"/g" ${STAGE}/DEBIAN/postinst
+        sed -i "s/^CENTAURINI.*/CENTAURINI=${SETUP_DIR}\/${PCK_NAME}\/config\/centaur.ini/g" ${STAGE}/DEBIAN/postinst
     
-    cp -r DEBIAN ${STAGE}/
  
     # Set permissions
     sudo chown -R root.root ${STAGE}/etc

--- a/build/system/etc/systemd/system/stopDGTController.service
+++ b/build/system/etc/systemd/system/stopDGTController.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Power off DGT controller.
 DefaultDependencies=no
-Before=shutdown.target reboot.target halt.target
+Conflicts=reboot.target
+Before=poweroff.target halt.target shutdown.target
+Requires=poweroff.target
 
 [Service]
 ExecStart=shutdown.py

--- a/build/system/etc/systemd/system/stopDGTController.service
+++ b/build/system/etc/systemd/system/stopDGTController.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Power off DGT controller.
+DefaultDependencies=no
+Before=shutdown.target reboot.target halt.target
+
+[Service]
+ExecStart=shutdown.py
+Environment=
+WorkingDirectory=
+Type=oneshot
+
+[Install]
+WantedBy=shutdown.target


### PR DESCRIPTION
Added a shutdown service to ensure the controller gets turned off properly. Works both in menu and when shutdown is issued over other methods (SSH, web GUI). This service calls board.shutdown() function outside of DGTCM so any shutdown will trigger controller shutdown.
I have the service implemented into the build process as well.

Have a look for a review and to be aware of new changes in the code, 
I will merge this tomorrow.
