### PR TITLE
Fixed: Build local even if local repo folder name is different

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -127,7 +127,8 @@ function stage {
 function buildLocal {
     VERSION=0-local-$(git branch | grep "*" | cut -f2 -d' ')
     FILEVERSION=local-$(git branch | grep "*" | cut -f2 -d' ')
-    cp -r $(pwd)/../../${REPO_NAME} /tmp//${REPO_NAME}
+    LOCAL_REPO=`pwd | cut -d/ -f5`
+    cp -r $(pwd)/../../${LOCAL_REPO} /tmp//${REPO_NAME}
     REPO_NAME="/tmp/${REPO_NAME}"
     stage
 }


### PR DESCRIPTION
When local folder had a different name and not DGTCentaur, the `./build.sh local` command was failing.

Test:
```
pi@zero-w2:~/dev $ mv DGTCentaur DGTCentaur-test
pi@zero-w2:~/dev $ cd DGTCentaur-test/build/
pi@zero-w2:~/dev/DGTCentaur-test/build $ ./build.sh local
::: Configuring service:  DGTCentaurMods.service
::: Configuring service: centaurmods-web.service
::: Configuring postinst.
DO you want to integrate Stockfish for this build? (y/n):
```