### PR TITLE
Implement prerm maintenance script

### DIFF
--- a/build/DEBIAN/postrm
+++ b/build/DEBIAN/postrm
@@ -1,11 +1,14 @@
 #!/usr/bin/bash
-set -e
+
+
+function reloadSystemd {
+    systemctl daemon-reload
+}
+
 
 case $1 in
-remove* )
-    ;;
-
-purge* )
-    ;;
-
+    remove* )
+        reloadSystemd
+        exit 0
+        ;;
 esac

--- a/build/DEBIAN/postrm
+++ b/build/DEBIAN/postrm
@@ -1,14 +1,24 @@
 #!/usr/bin/bash
 
+INSTALL_DIR="/home/pi/DGTCentaurMods"
 
 function reloadSystemd {
     systemctl daemon-reload
 }
 
 
+function completeDGTCMremove {
+    rm -rf ${INSTALL_DIR}
+}
+
+
+#Default actions on postrm
+reloadSystemd
+
+
 case $1 in
-    remove* )
-        reloadSystemd
+    purge* )
+        completeDGTCMremove
         exit 0
         ;;
 esac

--- a/build/DEBIAN/prerm
+++ b/build/DEBIAN/prerm
@@ -8,6 +8,9 @@ function removePycache {
 
 
 function stopServices {
+    systemctl stop rfcomm.service
+    systemctl stop centaurmods-web.service
+    systemctl stop DGTCentaurMods.service
     systemctl stop var-run-sdp.path
     systemctl stop var-run-sdp.service
     systemctl stop stopDGTController.service

--- a/build/DEBIAN/prerm
+++ b/build/DEBIAN/prerm
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+INSTALL_DIR="/home/pi/DGTCentaurMods"
+
+function removePycache {    
+    find ${INSTALL_DIR} | grep -E "(__pycache__|\.pyc|\.pyo$|epaper.jpg|tmp)" | xargs rm -rf
+}
+
+
+case $1 in
+    remove* )
+        removePycache
+        exit 0
+        ;;
+esac

--- a/build/DEBIAN/prerm
+++ b/build/DEBIAN/prerm
@@ -7,9 +7,18 @@ function removePycache {
 }
 
 
+function stopServices {
+    systemctl stop var-run-sdp.path
+    systemctl stop var-run-sdp.service
+    systemctl stop stopDGTController.service
+    systemctl stop var-run-sdp.path
+}
+
+
 case $1 in
     remove* )
         removePycache
+        stopServices
         exit 0
         ;;
 esac

--- a/build/build.sh
+++ b/build/build.sh
@@ -112,7 +112,7 @@ function stage {
     mkdir -p ${STAGE}/DEBIAN ${STAGE}/${SETUP_DIR} 
     
     # Move system services
-    mv -v $REPO_NAME/build/system/* ${STAGE}/
+    mv $REPO_NAME/build/system/* ${STAGE}/
     
     # Removed unnecessary stuff
     #rm -rf $REPO_NAME/${PCK_NAME}/etc
@@ -123,7 +123,7 @@ function stage {
     mv  $REPO_NAME/requirements.txt ${STAGE}/${SETUP_DIR}/${PCK_NAME}
 
     # Remove files from Git
-    rm -rfv $REPO_NAME
+    rm -rf $REPO_NAME
 }
 
 


### PR DESCRIPTION
Will remove all __pycache__, pyc, tmp and epaper.jpg files preventing complete removal of dgtcentaurmods.
Removed verbosity for some commands in build script.