### PR TITLE
Gui restart and poweroff. Dev tool to toggle between installed DGTCentaurMods software and current workspace

### DIFF
--- a/DGTCentaurMods/game/menu.py
+++ b/DGTCentaurMods/game/menu.py
@@ -130,6 +130,7 @@ def doMenu(menu):
         if res[24] == 0 and res[25] == 0 and res[26] == 0 and res[27] == 0 and res[28] == 0 and res[29] == 0 and res[30] == 0 and res[31] == 0:
             quickselect = 1
     row = 1
+    epaper.writeText(0,"                      ")
     for k, v in menu.items():
         epaper.writeText(row,"    " + str(v))
         row = row + 1
@@ -213,7 +214,7 @@ while True:
             board.pauseEvents()
             os.system("sudo " + str(sys.executable) + " " + str(pathlib.Path(__file__).parent.resolve()) + "/eboard.py")
             board.unPauseEvents()
-        if result == "millenium":
+        if result == "millenmium":
             epaper.clearScreen()
             epaper.writeText(0, "Loading...")
             board.pauseEvents()

--- a/DGTCentaurMods/web/app.py
+++ b/DGTCentaurMods/web/app.py
@@ -114,22 +114,13 @@ def license():
 @app.route("/return2dgtcentaurmods")
 def return2dgtcentaurmods():
 	os.system("pkill centaur")
-	time.sleep(3)
+	time.sleep(1)
 	os.system("sudo systemctl restart DGTCentaurMods.service")
 	return "ok"
 
 @app.route("/shutdownboard")
 def shutdownboard():
 	os.system("pkill centaur")
-	os.system("sudo systemctl stop DGTCentaurMods.service")
-	time.sleep(1)
-	epaper.initEpaper(1)
-	epaper.epd.init()
-	#epaper.epd.HalfClear()
-	time.sleep(5)
-	epaper.stopEpaper()
-	#os.system("sudo systemctl start stopDGTController.service")
-	#time.sleep(1)
 	os.system("sudo poweroff")
 	return "ok"
 

--- a/DGTCentaurMods/web/app.py
+++ b/DGTCentaurMods/web/app.py
@@ -22,6 +22,7 @@
 from flask import Flask, render_template, Response, request, redirect
 from DGTCentaurMods.db import models
 from DGTCentaurMods.board import centaur
+from DGTCentaurMods.display import epaper
 from board import LiveBoard
 from PIL import Image, ImageDraw, ImageFont
 from sqlalchemy.orm import sessionmaker
@@ -30,6 +31,7 @@ from sqlalchemy.sql import func
 from sqlalchemy import select
 from sqlalchemy import delete
 import os
+import time
 import pathlib
 import io
 import chess
@@ -108,6 +110,28 @@ def support():
 @app.route("/license")
 def license():
 	return render_template('license.html')
+
+@app.route("/return2dgtcentaurmods")
+def return2dgtcentaurmods():
+	os.system("pkill centaur")
+	time.sleep(3)
+	os.system("sudo systemctl restart DGTCentaurMods.service")
+	return "ok"
+
+@app.route("/shutdownboard")
+def shutdownboard():
+	os.system("pkill centaur")
+	os.system("sudo systemctl stop DGTCentaurMods.service")
+	time.sleep(1)
+	epaper.initEpaper(1)
+	epaper.epd.init()
+	#epaper.epd.HalfClear()
+	time.sleep(5)
+	epaper.stopEpaper()
+	#os.system("sudo systemctl start stopDGTController.service")
+	#time.sleep(1)
+	os.system("sudo poweroff")
+	return "ok"
 
 @app.route("/lichesskey/<key>")
 def lichesskey(key):

--- a/DGTCentaurMods/web/templates/configure.html
+++ b/DGTCentaurMods/web/templates/configure.html
@@ -45,6 +45,34 @@
 
 <div style="width:100%">
     <div id="settings">
+      <article class="panel is-info">
+        <p class="panel-heading">
+          Shutdown/Restart DGTCentaurMods
+        </p>
+          <div class="panel-block">
+              <p>
+              Here you can return to DGTCentaurMods when playing the original Centaur
+              by pressing "Quit orig Centaur" 
+              </p>
+          </div>
+ 
+          <div class="panel-block">
+            <div class="is-pulled-right" style="width:100%">
+              <button class="button is-pulled-right" id="return2DGTMods" style="margin-left:10px;" onClick="returnToDGTCentaurMods()">Quit orig Centaur</button>
+            </div>
+            </div>
+
+            <div class="panel-block">
+              <p >
+  Poweroff the board by pressing "Shutdown"
+              </p>
+          </div>
+          <div class="panel-block">       
+            <div class="is-pulled-right" style="width:100%">
+            <button class="button is-pulled-right" id="shutDownBoard" style="margin-left:10px;" onClick="shutDownBoard()">Shutdown</button>
+            </div>
+          </div>
+      </article>
         <article class="panel is-info">
           <p class="panel-heading">
             Lichess
@@ -109,6 +137,22 @@
 <script>
 
     var page = 1;
+    function shutDownBoard() {
+        var xmlhttp;
+        xmlhttp = new XMLHttpRequest();
+
+        xmlhttp.open("GET", "/shutdownboard", true);
+        xmlhttp.send();
+    }
+
+
+    function returnToDGTCentaurMods() {
+        var xmlhttp;
+        xmlhttp = new XMLHttpRequest();
+
+        xmlhttp.open("GET", "/return2dgtcentaurmods", true);
+        xmlhttp.send();
+    }
 
     function saveLichess() {
         var newkey = document.getElementById("lichesskey").value;

--- a/tools/dev-tools/toggle_deb_and_dev_environment.sh
+++ b/tools/dev-tools/toggle_deb_and_dev_environment.sh
@@ -1,0 +1,63 @@
+LOCAL_REPO=$(dirname $(dirname $PWD))
+PCK_NAME="DGTCentaurMods"
+SETUP_DIR="/home/pi"
+
+function toggleDebian {
+# Setup DGT Centaur Mods service
+echo "::: Configuring service:  DGTCentaurMods.service"
+sudo sed -i "s,WorkingDirectory=.*,WorkingDirectory=${SETUP_DIR}/${PCK_NAME},g" /etc/systemd/system/DGTCentaurMods.service
+sudo sed -i "s,Environment=.*,Environment=\"PYTHONPATH=${SETUP_DIR}\",g" /etc/systemd/system/DGTCentaurMods.service
+        
+# Setup web service
+echo "::: Configuring service: centaurmods-web.service"
+sudo sed -i "s,WorkingDirectory=.*,WorkingDirectory=${SETUP_DIR}/${PCK_NAME}/web,g" /etc/systemd/system/centaurmods-web.service
+sudo sed -i "s,Environment=.*,Environment=\"PYTHONPATH=${SETUP_DIR}\",g" /etc/systemd/system/centaurmods-web.service
+        
+echo "::: Configuring service: stopDGTController.service"
+sudo sed -i "s,WorkingDirectory=.*,WorkingDirectory=${SETUP_DIR}/${PCK_NAME},g" /etc/systemd/system/stopDGTController.service
+sudo sed -i "s,ExecStart=.*,ExecStart=python3 board/shutdown.py,g" /etc/systemd/system/stopDGTController.service
+sudo sed -i "s,Environment=.*,Environment=\"PYTHONPATH=${SETUP_DIR}\",g"	/etc/systemd/system/stopDGTController.service
+sudo rm -rf /usr/lib/python3/dist-packages/DGTCentaurMods
+sudo ln -s ${SETUP_DIR}/${PCK_NAME} /usr/lib/python3/dist-packages/DGTCentaurMods
+
+}
+
+function toggleLocalRepo {
+# Setup DGT Centaur Mods service
+echo "::: Configuring service:  DGTCentaurMods.service"
+sudo sed -i "s,WorkingDirectory=.*,WorkingDirectory=${LOCAL_REPO}/${PCK_NAME},g" /etc/systemd/system/DGTCentaurMods.service
+sudo sed -i "s,Environment=.*,Environment=\"PYTHONPATH=${LOCAL_REPO}\",g" /etc/systemd/system/DGTCentaurMods.service
+        
+# Setup web service
+echo "::: Configuring service: centaurmods-web.service"
+sudo sed -i "s,WorkingDirectory=.*,WorkingDirectory=${LOCAL_REPO}/${PCK_NAME}/web,g" /etc/systemd/system/centaurmods-web.service
+sudo sed -i "s,Environment=.*,Environment=\"PYTHONPATH=${LOCAL_REPO}\",g" /etc/systemd/system/centaurmods-web.service
+        
+echo "::: Configuring service: stopDGTController.service"
+sudo sed -i "s,WorkingDirectory=.*,WorkingDirectory=${LOCAL_REPO}/${PCK_NAME},g" /etc/systemd/system/stopDGTController.service
+sudo sed -i "s,ExecStart=.*,ExecStart=python3 board/shutdown.py,g" /etc/systemd/system/stopDGTController.service
+sudo sed -i "s,Environment=.*,Environment=\"PYTHONPATH=${LOCAL_REPO}\",g"	/etc/systemd/system/stopDGTController.service
+sudo rm -rf /usr/lib/python3/dist-packages/DGTCentaurMods
+sudo ln -s ${LOCAL_REPO}/${PCK_NAME} /usr/lib/python3/dist-packages/DGTCentaurMods
+
+}
+
+
+
+echo "You can toggle services between debian install and your local branch"
+echo "1 - debian install ${SETUP_DIR}/${PCK_NAME}"
+echo "2 - local repo     ${LOCAL_REPO}/${PCK_NAME}"
+read -p "choose 1 or 2?:"
+case $REPLY in
+    [1]* ) toggleDebian;;
+    [2]* ) toggleLocalRepo;;
+esac
+
+#cat /etc/systemd/system/DGTCentaurMods.service
+#cat /etc/systemd/system/centaurmods-web.service
+#cat /etc/systemd/system/stopDGTController.service
+
+sudo systemctl daemon-reload
+sudo systemctl restart DGTCentaurMods
+sudo systemctl restart centaurmods-web
+


### PR DESCRIPTION
Added two buttons to the configure Web page:

one  to restart DGTCentaurMods when playing the original centaur software.
another to poweroff the board and show the logo and qrcode

In addition I added a shell script in /tools/dev-tools which allow to toggle between installed DGTCentaurMods software and the current workspace.