### PR TITLE
Pegasus

### DIFF
--- a/DGTCentaurMods/game/ble.py
+++ b/DGTCentaurMods/game/ble.py
@@ -1,0 +1,143 @@
+# DGT Centaur BLE Control
+#
+# This file is part of the DGTCentaur Mods open source software
+# ( https://github.com/EdNekebno/DGTCentaur )
+#
+# DGTCentaur Mods is free software: you can redistribute
+# it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# DGTCentaur Mods is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see
+#
+# https://github.com/EdNekebno/DGTCentaur/blob/master/LICENSE.md
+#
+# This and any other notices must remain intact and unaltered in any
+# distribution, modification, variant, or derivative of this software.
+
+import dbus
+from DGTCentaurMods.thirdparty.advertisement import Advertisement
+from DGTCentaurMods.thirdparty.service import Application, Service, Characteristic, Descriptor
+from DGTCentaurMods.board import *
+import time
+import threading
+import random
+
+GATT_CHRC_IFACE = "org.bluez.GattCharacteristic1"
+NOTIFY_TIMEOUT = 5000
+
+class UARTAdvertisement(Advertisement):
+    def __init__(self, index):
+        Advertisement.__init__(self, index, "peripheral")
+        self.add_local_name("PCS-REVII-081500")
+        self.include_tx_power = True
+        self.add_service_uuid("5f040001-5866-11ec-bf63-0242ac130002")
+
+class UARTService(Service):
+
+    tx_obj = None
+
+    UART_SVC_UUID = "5f040001-5866-11ec-bf63-0242ac130002"
+
+    def __init__(self, index):
+        Service.__init__(self, index, self.UART_SVC_UUID, True)
+        self.add_characteristic(UARTTXCharacteristic(self))
+        self.add_characteristic(UARTRXCharacteristic(self))
+
+class UARTRXCharacteristic(Characteristic):
+    UARTRX_CHARACTERISTIC_UUID = "5f040002-5866-11ec-bf63-0242ac130002"
+
+    def __init__(self, service):
+
+        Characteristic.__init__(
+                self, self.UARTRX_CHARACTERISTIC_UUID,
+                ["write"], service)
+
+    def sendMessage(self, data):
+        # Send a message
+        tosend = bytearray()
+        for x in range(0, len(data)):
+            tosend.append(data[x])
+        UARTService.tx_obj.updateValue(tosend)
+
+    def WriteValue(self, value, options):
+        # When the remote device writes data, it comes here
+        print("Received")
+        print(value)
+        bytes = bytearray()
+        for i in range(0,len(value)):
+            bytes.append(value[i])
+        print(len(bytes))
+        print(bytes)
+
+class UARTTXCharacteristic(Characteristic):
+    UARTTX_CHARACTERISTIC_UUID = "5f040003-5866-11ec-bf63-0242ac130002"
+
+    def __init__(self, service):
+
+        Characteristic.__init__(
+                self, self.UARTTX_CHARACTERISTIC_UUID,
+                ["read", "notify"], service)
+        self.notifying = False
+
+    def checkSend(self):
+        if self.notifying == True:
+            msg = bytearray()
+            msg.append(random.randrange(65,90))
+            print("----")
+            print(msg)
+            self.sendMessage(msg)
+        return self.notifying
+
+    def sendMessage(self, data):
+        # Send a message
+        print(data)
+        tosend = bytearray()
+        for x in range(0, len(data)):
+            tosend.append(data[x])
+        UARTService.tx_obj.updateValue(tosend)
+
+    def StartNotify(self):
+        print("started notifying")
+        UARTService.tx_obj = self
+        self.notifying = True
+        self.add_timeout(200, self.checkSend)
+        return self.notifying
+
+    def StopNotify(self):
+        if not self.notifying:
+            return
+        self.notifying = False
+        return self.notifying
+
+    def updateValue(self,value):
+        if not self.notifying:
+            return
+        send = dbus.Array(signature=dbus.Signature('y'))
+        for i in range(0,len(value)):
+            send.append(dbus.Byte(value[i]))
+        self.PropertiesChanged( GATT_CHRC_IFACE, { 'Value': send }, [])
+
+    def ReadValue(self, options):
+        print("read value")
+        value = bytearray()
+        value.append(1)
+        return value
+
+app = Application()
+app.add_service(UARTService(0))
+app.register()
+
+adv = UARTAdvertisement(0)
+adv.register()
+
+try:
+    app.run()
+except KeyboardInterrupt:
+    app.quit()

--- a/DGTCentaurMods/game/menu.py
+++ b/DGTCentaurMods/game/menu.py
@@ -205,6 +205,7 @@ while True:
         boardmenu = {
             'dgtclassic' : 'DGT REVII',
             'millennium' : 'Millennium',
+            'pegasus' : 'Pegasus',
         }
         result = doMenu(boardmenu)
         if result == "dgtclassic":
@@ -218,6 +219,12 @@ while True:
             epaper.writeText(0, "Loading...")
             board.pauseEvents()
             os.system("sudo " + str(sys.executable) + " " + str(pathlib.Path(__file__).parent.resolve()) + "/millenium.py")
+            board.unPauseEvents()
+        if result == "pegasus":
+            epaper.clearScreen()
+            epaper.writeText(0, "Loading...")
+            board.pauseEvents()
+            os.system(str(sys.executable) + " " + str(pathlib.Path(__file__).parent.resolve()) + "/pegasus.py")
             board.unPauseEvents()
     if result == "settings":
         setmenu = {

--- a/DGTCentaurMods/game/pegasus.py
+++ b/DGTCentaurMods/game/pegasus.py
@@ -1,0 +1,335 @@
+# DGT Centaur Pegasus Emulation
+#
+# This file is part of the DGTCentaur Mods open source software
+# ( https://github.com/EdNekebno/DGTCentaur )
+#
+# DGTCentaur Mods is free software: you can redistribute
+# it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# DGTCentaur Mods is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see
+#
+# https://github.com/EdNekebno/DGTCentaur/blob/master/LICENSE.md
+#
+# This and any other notices must remain intact and unaltered in any
+# distribution, modification, variant, or derivative of this software.
+
+import dbus
+from DGTCentaurMods.thirdparty.advertisement import Advertisement
+from DGTCentaurMods.thirdparty.service import Application, Service, Characteristic, Descriptor
+from DGTCentaurMods.board import *
+import time
+import threading
+import os
+from DGTCentaurMods.board import *
+from DGTCentaurMods.display import epaper
+
+kill = 0
+
+epaper.initEpaper()
+
+for x in range(0,10):
+    board.sendPacket(b'\x83', b'')
+    expect = board.buildPacket(b'\x85\x00\x06', b'')
+    resp = board.ser.read(10000)
+    resp = bytearray(resp)
+    board.sendPacket(b'\x94', b'')
+    expect = board.buildPacket(b'\xb1\x00\x06', b'')
+    resp = board.ser.read(10000)
+    resp = bytearray(resp)
+
+epaper.writeText(1,"PEGASUS MODE")
+epaper.writeText(2,"PCS-REVII-081500")
+epaper.writeText(3,"Use back button")
+epaper.writeText(4,"to exit mode")
+epaper.writeText(5,"Await Connect")
+
+GATT_CHRC_IFACE = "org.bluez.GattCharacteristic1"
+NOTIFY_TIMEOUT = 5000
+DGT_MSG_BOARD_DUMP = 134
+DGT_MSG_FIELD_UPDATE = 142
+DGT_MSG_UNKNOWN_143 = 143
+DGT_MSG_UNKNOWN_144 = 144
+DGT_MSG_SERIALNR = 145
+DGT_MSG_TRADEMARK = 146
+DGT_MSG_VERSION = 147
+DGT_MSG_HARDWARE_VERSION = 150
+DGT_MSG_BATTERY_STATUS = 160
+DGT_MSG_LONG_SERIALNR = 162
+DGT_MSG_UNKNOWN_163 = 163
+DGT_MSG_LOCK_STATE = 164
+DGT_MSG_DEVKEY_STATE = 165
+
+class UARTAdvertisement(Advertisement):
+    def __init__(self, index):
+        Advertisement.__init__(self, index, "peripheral")
+        self.add_local_name("PCS-REVII-081500")
+        #self.add_local_name("DGT_PEGASUS_EMULATION")
+        self.include_tx_power = True
+        self.add_service_uuid("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+
+class UARTService(Service):
+
+    tx_obj = None
+
+    UART_SVC_UUID = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E"
+
+    def __init__(self, index):
+        Service.__init__(self, index, self.UART_SVC_UUID, True)
+        self.add_characteristic(UARTTXCharacteristic(self))
+        self.add_characteristic(UARTRXCharacteristic(self))
+
+class UARTRXCharacteristic(Characteristic):
+    UARTRX_CHARACTERISTIC_UUID = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
+
+    def __init__(self, service):
+
+        Characteristic.__init__(
+                self, self.UARTRX_CHARACTERISTIC_UUID,
+                ["write"], service)
+
+    def sendMessage(self, msgtype, data):
+        # Send a message of the given type
+        tosend = bytearray()
+        # First the message type, then the length
+        tosend.append(msgtype)
+        lo = (len(data)+3) & 127
+        hi = ((len(data)+3) >> 7) & 127
+        tosend.append(hi)
+        tosend.append(lo)
+        for x in range(0, len(data)):
+            tosend.append(data[x])
+        UARTService.tx_obj.updateValue(tosend)
+
+    def WriteValue(self, value, options):
+        # When the remote device writes data, it comes here
+        print("Received")
+        print(value)
+        bytes = bytearray()
+        for i in range(0,len(value)):
+            bytes.append(value[i])
+        print(len(bytes))
+        print(bytes)
+        processed = 0
+        if len(bytes) == 1 and bytes[0] == ord('B'):
+            bs = board.getBoardState()
+            self.sendMessage(DGT_MSG_BOARD_DUMP, bs)
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('D'):
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('E'):
+            self.sendMessage(DGT_MSG_SERIALNR, [ord('A'),ord('B'),ord('C'),ord('D'),ord('E')])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('F'):
+            self.sendMessage(DGT_MSG_UNKNOWN_144, [0])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('G'):
+            # Return a DGT_MSG_TRADEMARK but it must contain
+            # Digital Game Technology\r\nCopyright (c)
+            tm = b'Digital Game Technology\r\nCopyright (c) 2021 DGT\r\nsoftware version: 1.00, build: 210722\r\nhardware version: 1.00, serial no: PXXXXXXXXX'
+            self.sendMessage(DGT_MSG_TRADEMARK, tm)
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('H'):
+            self.sendMessage(DGT_MSG_HARDWARE_VERSION,[1,0])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('I'):
+            self.sendMessage(DGT_MSG_UNKNOWN_143, [])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('L'):
+            self.sendMessage(DGT_MSG_BATTERY_STATUS, [0x58,0,0,0,0,0,0,0,2])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('M'):
+            self.sendMessage(DGT_MSG_VERSION, [1,0])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('U'):
+            self.sendMessage(DGT_MSG_LONG_SERIALNR, [ord('A'),ord('B'),ord('C'),ord('D'),ord('E'),ord('F'),ord('G'),ord('H'),ord('I'),ord('J')])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('V'):
+            self.sendMessage(DGT_MSG_UNKNOWN_163, [0])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('Y'):
+            self.sendMessage(DGT_MSG_LOCK_STATE, [0])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('Z'):
+            self.sendMessage(DGT_MSG_DEVKEY_STATE, [0])
+            processed = 1
+        if len(bytes) == 1 and bytes[0] == ord('@'):
+            # This looks like some sort of reset, but it is used mid game after a piece has been moved sometimes.
+            # Maybe it does something with LEDs as it was followed by a switching off leds
+            # Let's report the battery status here - 0x58 (or presumably higher as there is rounding) = 100%
+            # As I can't read centaur battery percentage here - fake it
+            self.sendMessage(DGT_MSG_BATTERY_STATUS, [0x58,0,0,0,0,0,0,0,2])
+            processed=1
+        if bytes[0] == 99:
+            # This registers the board with a developer key. No clue what this actually does
+            msg = b'\x01' # Guessing, this isn't checked
+            self.sendMessage(DGT_MSG_DEVKEY_STATE, msg)
+            processed=1
+        if len(bytes) == 4:
+            if bytes[0] == 96 and bytes[1] == 2 and bytes[2] == 0 and bytes[3] == 0:
+                # ledsOff
+                print("leds off")
+                board.ledsOff()
+                # Let's report the battery status here - 0x58 (or presumably higher as there is rounding) = 100%
+                # As I can't read centaur battery percentage here - fake it
+                self.sendMessage(DGT_MSG_BATTERY_STATUS, [0x58,0,0,0,0,0,0,0,2])
+                processed=1
+        if processed == 0 and bytes[0] == 96:
+            # LEDS stuff
+            # 96, [Packet data length - 2], 5(light leds), LedSpeed, 0 or 1 is 0 except in moveLed or checkLed, Intensity, ...field ids, 0
+            print("Received LED command")
+            ledspeed = bytes[3]
+            intensity = bytes[5]
+            data = bytearray()
+            data.append(5)
+            data.append(ledspeed)
+            data.append(0)
+            data.append(intensity)
+            print(data.hex())
+            for x in range(6,len(bytes)-1):
+                # This is looping through the leds to light
+                data.append(bytes[x])
+            head = bytearray()
+            head.append(176)
+            head.append(0)
+            head.append(len(data)+6)
+            print(head.hex())
+            print(data.hex())
+            board.ledsOff()
+            board.sendPacket(head,data)
+            if bytes[4] == 1:
+                time.sleep(0.5)
+                board.ledsOff()
+            # Let's report the battery status here - 0x58 (or presumably higher as there is rounding) = 100%
+            # As I can't read centaur battery percentage here - fake it
+            #msg = b'\x58'
+            #self.sendMessage(DGT_MSG_BATTERY_STATUS, msg)
+            processed=1
+        if processed==0:
+            print("Un-coded command")
+            UARTService.tx_obj.updateValue(bytes)
+
+
+class UARTTXCharacteristic(Characteristic):
+    UARTTX_CHARACTERISTIC_UUID = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+
+    def __init__(self, service):
+
+        Characteristic.__init__(
+                self, self.UARTTX_CHARACTERISTIC_UUID,
+                ["read", "notify"], service)
+        self.notifying = False
+        print("setting timeout")
+        self.add_timeout(300, self.checkBoard)
+
+    def checkBoard(self):
+        if self.notifying == True:
+            board.sendPacket(b'\x83', b'')
+            expect = board.buildPacket(b'\x85\x00\x06', b'')
+            resp = board.ser.read(10000)
+            resp = bytearray(resp)
+            if (bytearray(resp) != expect):
+                if (resp[0] == 133 and resp[1] == 0):
+                    for x in range(0, len(resp) - 1):
+                        if (resp[x] == 64):
+                            fieldHex = resp[x + 1]
+                            msg = bytearray()
+                            msg.append(fieldHex)
+                            msg.append(0)
+                            self.sendMessage(DGT_MSG_FIELD_UPDATE, msg)
+                            #msg = b'\x58'
+                            #self.sendMessage(DGT_MSG_BATTERY_STATUS, msg)
+                        if (resp[x] == 65):
+                            fieldHex = resp[x + 1]
+                            msg = bytearray()
+                            msg.append(fieldHex)
+                            msg.append(1)
+                            self.sendMessage(DGT_MSG_FIELD_UPDATE, msg)
+                            #msg = b'\x58'
+                            #self.sendMessage(DGT_MSG_BATTERY_STATUS, msg)
+            board.sendPacket(b'\x94', b'')
+            expect = board.buildPacket(b'\xb1\x00\x06', b'')
+            resp = board.ser.read(10000)
+            resp = bytearray(resp)
+            if (resp.hex()[:-2] == "b10011" + "{:02x}".format(board.addr1) + "{:02x}".format(board.addr2) + "00140a0501000000007d47"):
+                print("Back button pressed")
+                # os.system('sudo service bluetooth restart')
+                app.quit()
+        else:
+            board.sendPacket(b'\x83', b'')
+            expect = board.buildPacket(b'\x85\x00\x06', b'')
+            resp = board.ser.read(10000)
+            board.sendPacket(b'\x94', b'')
+            expect = board.buildPacket(b'\xb1\x00\x06', b'')
+            resp = board.ser.read(10000)
+            resp = bytearray(resp)
+            if (resp.hex()[:-2] == "b10011" + "{:02x}".format(board.addr1) + "{:02x}".format(board.addr2) + "00140a0501000000007d47"):
+                print("Back button pressed")
+                # os.system('sudo service bluetooth restart')
+                app.quit()
+        return True
+
+    def sendMessage(self, msgtype, data):
+        # Send a message of the given type
+        tosend = bytearray()
+        # First the message type, then the length
+        tosend.append(msgtype)
+        lo = (len(data)+3) & 127
+        hi = ((len(data)+3) >> 7) & 127
+        tosend.append(hi)
+        tosend.append(lo)
+        for x in range(0, len(data)):
+            tosend.append(data[x])
+        UARTService.tx_obj.updateValue(tosend)
+
+    def StartNotify(self):
+        print("started notifying")
+        epaper.writeText(5, "Connected")
+        board.clearSerial()
+        board.clearBoardData()
+        board.beep(board.SOUND_GENERAL)
+        UARTService.tx_obj = self
+        self.notifying = True
+        board.ledsOff()
+        # Let's report the battery status here - 0x58 (or presumably higher as there is rounding) = 100%
+        # As I can't read centaur battery percentage here - fake it
+        #msg = b'\x58'
+        #self.sendMessage(DGT_MSG_BATTERY_STATUS, msg)
+        return self.notifying
+
+    def StopNotify(self):
+        if not self.notifying:
+            return
+        self.notifying = False
+        return self.notifying
+
+    def updateValue(self,value):
+        if not self.notifying:
+            return
+        send = dbus.Array(signature=dbus.Signature('y'))
+        for i in range(0,len(value)):
+            send.append(dbus.Byte(value[i]))
+        self.PropertiesChanged( GATT_CHRC_IFACE, { 'Value': send }, [])
+
+    def ReadValue(self, options):
+        value = 1
+        return value
+
+app = Application()
+app.add_service(UARTService(0))
+app.register()
+
+adv = UARTAdvertisement(0)
+adv.register()
+
+try:
+    app.run()
+except KeyboardInterrupt:
+    app.quit()

--- a/DGTCentaurMods/thirdparty/advertisement.py
+++ b/DGTCentaurMods/thirdparty/advertisement.py
@@ -1,0 +1,134 @@
+"""Copyright (c) 2019, Douglas Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import dbus
+import dbus.service
+
+from DGTCentaurMods.thirdparty.bletools import BleTools
+
+BLUEZ_SERVICE_NAME = "org.bluez"
+LE_ADVERTISING_MANAGER_IFACE = "org.bluez.LEAdvertisingManager1"
+DBUS_OM_IFACE = "org.freedesktop.DBus.ObjectManager"
+DBUS_PROP_IFACE = "org.freedesktop.DBus.Properties"
+LE_ADVERTISEMENT_IFACE = "org.bluez.LEAdvertisement1"
+
+
+class Advertisement(dbus.service.Object):
+    PATH_BASE = "/org/bluez/example/advertisement"
+
+    def __init__(self, index, advertising_type):
+        self.path = self.PATH_BASE + str(index)
+        self.bus = BleTools.get_bus()
+        self.ad_type = advertising_type
+        self.local_name = None
+        self.service_uuids = None
+        self.solicit_uuids = None
+        self.manufacturer_data = None
+        self.service_data = None
+        self.include_tx_power = None
+        dbus.service.Object.__init__(self, self.bus, self.path)
+
+    def get_properties(self):
+        properties = dict()
+        properties["Type"] = self.ad_type
+
+        if self.local_name is not None:
+            properties["LocalName"] = dbus.String(self.local_name)
+
+        if self.service_uuids is not None:
+            properties["ServiceUUIDs"] = dbus.Array(self.service_uuids,
+                                                    signature='s')
+        if self.solicit_uuids is not None:
+            properties["SolicitUUIDs"] = dbus.Array(self.solicit_uuids,
+                                                    signature='s')
+        if self.manufacturer_data is not None:
+            properties["ManufacturerData"] = dbus.Dictionary(
+                self.manufacturer_data, signature='qv')
+
+        if self.service_data is not None:
+            properties["ServiceData"] = dbus.Dictionary(self.service_data,
+                                                        signature='sv')
+        if self.include_tx_power is not None:
+            properties["IncludeTxPower"] = dbus.Boolean(self.include_tx_power)
+
+        if self.local_name is not None:
+            properties["LocalName"] = dbus.String(self.local_name)
+
+        return {LE_ADVERTISEMENT_IFACE: properties}
+
+    def get_path(self):
+        return dbus.ObjectPath(self.path)
+
+    def add_service_uuid(self, uuid):
+        if not self.service_uuids:
+            self.service_uuids = []
+        self.service_uuids.append(uuid)
+
+    def add_solicit_uuid(self, uuid):
+        if not self.solicit_uuids:
+            self.solicit_uuids = []
+        self.solicit_uuids.append(uuid)
+
+    def add_manufacturer_data(self, manuf_code, data):
+        if not self.manufacturer_data:
+            self.manufacturer_data = dbus.Dictionary({}, signature="qv")
+        self.manufacturer_data[manuf_code] = dbus.Array(data, signature="y")
+
+    def add_service_data(self, uuid, data):
+        if not self.service_data:
+            self.service_data = dbus.Dictionary({}, signature="sv")
+        self.service_data[uuid] = dbus.Array(data, signature="y")
+
+    def add_local_name(self, name):
+        if not self.local_name:
+            self.local_name = ""
+        self.local_name = dbus.String(name)
+
+    @dbus.service.method(DBUS_PROP_IFACE,
+                         in_signature="s",
+                         out_signature="a{sv}")
+    def GetAll(self, interface):
+        if interface != LE_ADVERTISEMENT_IFACE:
+            raise InvalidArgsException()
+
+        return self.get_properties()[LE_ADVERTISEMENT_IFACE]
+
+    @dbus.service.method(LE_ADVERTISEMENT_IFACE,
+                         in_signature='',
+                         out_signature='')
+    def Release(self):
+        print ('%s: Released!' % self.path)
+
+    def register_ad_callback(self):
+        print("GATT advertisement registered")
+
+    def register_ad_error_callback(self):
+        print("Failed to register GATT advertisement")
+
+    def register(self):
+        bus = BleTools.get_bus()
+        adapter = BleTools.find_adapter(bus)
+
+        ad_manager = dbus.Interface(bus.get_object(BLUEZ_SERVICE_NAME, adapter),
+                                LE_ADVERTISING_MANAGER_IFACE)
+        ad_manager.RegisterAdvertisement(self.get_path(), {},
+                                     reply_handler=self.register_ad_callback,
+                                     error_handler=self.register_ad_error_callback)

--- a/DGTCentaurMods/thirdparty/bletools.py
+++ b/DGTCentaurMods/thirdparty/bletools.py
@@ -1,0 +1,57 @@
+"""Copyright (c) 2019, Douglas Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import dbus
+try:
+  from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
+
+BLUEZ_SERVICE_NAME = "org.bluez"
+LE_ADVERTISING_MANAGER_IFACE = "org.bluez.LEAdvertisingManager1"
+DBUS_OM_IFACE = "org.freedesktop.DBus.ObjectManager"
+
+class BleTools(object):
+    @classmethod
+    def get_bus(self):
+         bus = dbus.SystemBus()
+
+         return bus
+
+    @classmethod
+    def find_adapter(self, bus):
+        remote_om = dbus.Interface(bus.get_object(BLUEZ_SERVICE_NAME, "/"),
+                               DBUS_OM_IFACE)
+        objects = remote_om.GetManagedObjects()
+
+        for o, props in objects.items():
+            if LE_ADVERTISING_MANAGER_IFACE in props:
+                return o
+
+        return None
+
+    @classmethod
+    def power_adapter(self):
+        adapter = self.get_adapter()
+
+        adapter_props = dbus.Interface(bus.get_object(BLUEZ_SERVICE_NAME, adapter),
+                "org.freedesktop.DBus.Properties");
+        adapter_props.Set("org.bluez.Adapter1", "Powered", dbus.Boolean(1))

--- a/DGTCentaurMods/thirdparty/service.py
+++ b/DGTCentaurMods/thirdparty/service.py
@@ -1,0 +1,315 @@
+"""Copyright (c) 2019, Douglas Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import dbus
+import dbus.mainloop.glib
+import dbus.exceptions
+try:
+  from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
+from DGTCentaurMods.thirdparty.bletools import BleTools
+
+BLUEZ_SERVICE_NAME = "org.bluez"
+GATT_MANAGER_IFACE = "org.bluez.GattManager1"
+DBUS_OM_IFACE =      "org.freedesktop.DBus.ObjectManager"
+DBUS_PROP_IFACE =    "org.freedesktop.DBus.Properties"
+GATT_SERVICE_IFACE = "org.bluez.GattService1"
+GATT_CHRC_IFACE =    "org.bluez.GattCharacteristic1"
+GATT_DESC_IFACE =    "org.bluez.GattDescriptor1"
+
+class InvalidArgsException(dbus.exceptions.DBusException):
+    _dbus_error_name = "org.freedesktop.DBus.Error.InvalidArgs"
+
+class NotSupportedException(dbus.exceptions.DBusException):
+    _dbus_error_name = "org.bluez.Error.NotSupported"
+
+class NotPermittedException(dbus.exceptions.DBusException):
+    _dbus_error_name = "org.bluez.Error.NotPermitted"
+
+class Application(dbus.service.Object):
+    def __init__(self):
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        self.mainloop = GObject.MainLoop()
+        self.bus = BleTools.get_bus()
+        self.path = "/"
+        self.services = []
+        self.next_index = 0
+        dbus.service.Object.__init__(self, self.bus, self.path)
+
+    def get_path(self):
+        return dbus.ObjectPath(self.path)
+
+    def add_service(self, service):
+        self.services.append(service)
+
+    @dbus.service.method(DBUS_OM_IFACE, out_signature = "a{oa{sa{sv}}}")
+    def GetManagedObjects(self):
+        response = {}
+
+        for service in self.services:
+            response[service.get_path()] = service.get_properties()
+            chrcs = service.get_characteristics()
+            for chrc in chrcs:
+                response[chrc.get_path()] = chrc.get_properties()
+                descs = chrc.get_descriptors()
+                for desc in descs:
+                    response[desc.get_path()] = desc.get_properties()
+
+        return response
+
+    def register_app_callback(self):
+        print("GATT application registered")
+
+    def register_app_error_callback(self, error):
+        print("Failed to register application: " + str(error))
+
+    def register(self):
+        adapter = BleTools.find_adapter(self.bus)
+
+        service_manager = dbus.Interface(
+                self.bus.get_object(BLUEZ_SERVICE_NAME, adapter),
+                GATT_MANAGER_IFACE)
+
+        service_manager.RegisterApplication(self.get_path(), {},
+                reply_handler=self.register_app_callback,
+                error_handler=self.register_app_error_callback)
+
+    def run(self):
+        self.mainloop.run()
+
+    def quit(self):
+        print("\nGATT application terminated")
+        self.mainloop.quit()
+
+class Service(dbus.service.Object):
+    PATH_BASE = "/org/bluez/example/service"
+
+    def __init__(self, index, uuid, primary):
+        self.bus = BleTools.get_bus()
+        self.path = self.PATH_BASE + str(index)
+        self.uuid = uuid
+        self.primary = primary
+        self.characteristics = []
+        self.next_index = 0
+        dbus.service.Object.__init__(self, self.bus, self.path)
+
+    def get_properties(self):
+        return {
+                GATT_SERVICE_IFACE: {
+                        'UUID': self.uuid,
+                        'Primary': self.primary,
+                        'Characteristics': dbus.Array(
+                                self.get_characteristic_paths(),
+                                signature='o')
+                }
+        }
+
+    def get_path(self):
+        return dbus.ObjectPath(self.path)
+
+    def add_characteristic(self, characteristic):
+        self.characteristics.append(characteristic)
+
+    def get_characteristic_paths(self):
+        result = []
+        for chrc in self.characteristics:
+            result.append(chrc.get_path())
+        return result
+
+    def get_characteristics(self):
+        return self.characteristics
+
+    def get_bus(self):
+        return self.bus
+
+    def get_next_index(self):
+        idx = self.next_index
+        self.next_index += 1
+
+        return idx
+
+    @dbus.service.method(DBUS_PROP_IFACE,
+                         in_signature='s',
+                         out_signature='a{sv}')
+    def GetAll(self, interface):
+        if interface != GATT_SERVICE_IFACE:
+            raise InvalidArgsException()
+
+        return self.get_properties()[GATT_SERVICE_IFACE]
+
+class Characteristic(dbus.service.Object):
+    """
+    org.bluez.GattCharacteristic1 interface implementation
+    """
+    def __init__(self, uuid, flags, service):
+        index = service.get_next_index()
+        self.path = service.path + '/char' + str(index)
+        self.bus = service.get_bus()
+        self.uuid = uuid
+        self.service = service
+        self.flags = flags
+        self.descriptors = []
+        self.next_index = 0
+        dbus.service.Object.__init__(self, self.bus, self.path)
+
+    def get_properties(self):
+        return {
+                GATT_CHRC_IFACE: {
+                        'Service': self.service.get_path(),
+                        'UUID': self.uuid,
+                        'Flags': self.flags,
+                        'Descriptors': dbus.Array(
+                                self.get_descriptor_paths(),
+                                signature='o')
+                }
+        }
+
+    def get_path(self):
+        return dbus.ObjectPath(self.path)
+
+    def add_descriptor(self, descriptor):
+        self.descriptors.append(descriptor)
+
+    def get_descriptor_paths(self):
+        result = []
+        for desc in self.descriptors:
+            result.append(desc.get_path())
+        return result
+
+    def get_descriptors(self):
+        return self.descriptors
+
+    @dbus.service.method(DBUS_PROP_IFACE,
+                         in_signature='s',
+                         out_signature='a{sv}')
+    def GetAll(self, interface):
+        if interface != GATT_CHRC_IFACE:
+            raise InvalidArgsException()
+
+        return self.get_properties()[GATT_CHRC_IFACE]
+
+    @dbus.service.method(GATT_CHRC_IFACE,
+                        in_signature='a{sv}',
+                        out_signature='ay')
+    def ReadValue(self, options):
+        print('Default ReadValue called, returning error')
+        raise NotSupportedException()
+
+    @dbus.service.method(GATT_CHRC_IFACE, in_signature='aya{sv}')
+    def WriteValue(self, value, options):
+        print('Default WriteValue called, returning error')
+        raise NotSupportedException()
+
+    @dbus.service.method(GATT_CHRC_IFACE)
+    def StartNotify(self):
+        print('Default StartNotify called, returning error')
+        raise NotSupportedException()
+
+    @dbus.service.method(GATT_CHRC_IFACE)
+    def StopNotify(self):
+        print('Default StopNotify called, returning error')
+        raise NotSupportedException()
+
+    @dbus.service.signal(DBUS_PROP_IFACE,
+                         signature='sa{sv}as')
+    def PropertiesChanged(self, interface, changed, invalidated):
+        pass
+
+    def get_bus(self):
+        bus = self.bus
+
+        return bus
+
+    def get_next_index(self):
+        idx = self.next_index
+        self.next_index += 1
+
+        return idx
+
+    def add_timeout(self, timeout, callback):
+        GObject.timeout_add(timeout, callback)
+
+
+class Descriptor(dbus.service.Object):
+    def __init__(self, uuid, flags, characteristic):
+        index = characteristic.get_next_index()
+        self.path = characteristic.path + '/desc' + str(index)
+        self.uuid = uuid
+        self.flags = flags
+        self.chrc = characteristic
+        self.bus = characteristic.get_bus()
+        dbus.service.Object.__init__(self, self.bus, self.path)
+
+    def get_properties(self):
+        return {
+                GATT_DESC_IFACE: {
+                        'Characteristic': self.chrc.get_path(),
+                        'UUID': self.uuid,
+                        'Flags': self.flags,
+                }
+        }
+
+    def get_path(self):
+        return dbus.ObjectPath(self.path)
+
+    @dbus.service.method(DBUS_PROP_IFACE,
+                         in_signature='s',
+                         out_signature='a{sv}')
+    def GetAll(self, interface):
+        if interface != GATT_DESC_IFACE:
+            raise InvalidArgsException()
+
+        return self.get_properties()[GATT_DESC_IFACE]
+
+    @dbus.service.method(GATT_DESC_IFACE,
+                        in_signature='a{sv}',
+                        out_signature='ay')
+    def ReadValue(self, options):
+        print ('Default ReadValue called, returning error')
+        raise NotSupportedException()
+
+    @dbus.service.method(GATT_DESC_IFACE, in_signature='aya{sv}')
+    def WriteValue(self, value, options):
+        print('Default WriteValue called, returning error')
+        raise NotSupportedException()
+
+
+class CharacteristicUserDescriptionDescriptor(Descriptor):
+    CUD_UUID = '2901'
+
+    def __init__(self, bus, index, characteristic):
+        self.writable = 'writable-auxiliaries' in characteristic.flags
+        self.value = array.array('B', b'This is a characteristic for testing')
+        self.value = self.value.tolist()
+        Descriptor.__init__(
+                self, bus, index,
+                self.CUD_UUID,
+                ['read', 'write'],
+                characteristic)
+
+    def ReadValue(self, options):
+        return self.value
+
+    def WriteValue(self, value, options):
+        if not self.writable:
+            raise NotPermittedException()
+        self.value = value

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ General Settings - Connect Wifi, Pair bluetooth, sound, lichess api token
 ## Roadmap
 
 Currently we are working on...
-1. Builds/Releases
+1. Releasing out first stable version.
 2. Squashing bugs
 3. BLE boards emulation
 4. Improving Gamemanager features (gamemanager is the central system that handles chess games)
@@ -65,7 +65,7 @@ In order to run the project on a Raspberry Pi Zero W, these are some steps to be
 Installation process takes some time, so sit back and have a beer. Once done, reboot your Raspberry Pi. If all went well, board should power on and the new DGTCentaurMods will start. You'll notice the menu on the display.
 
 ## Automatic setup of SD card
-Use the tool in tools/card-setup-tol. Follow this wiki page. (to be filled)
+Use the tool in tools/card-setup-tol. Follow the README section on tool's page.
 
 ## Original centaur software
 


### PR DESCRIPTION
Changes to provide DGT Pegasus emulation.

Should work on DGT Chess app for iOS and Android (for android, pair first).
Android tries to connect bluetooth classic first - therefore on Android chess.com app does not work - use the millennium emulation to do that. iOS should work but chess.com haven't added that functionality to the app yet (apparently expected March)
WhitePawn - is buggy and does not let you scroll the list of other devices now, which makes it impossible to test to see :)

In DGT Chess app make sure the board is actually connected. The DGT Chess app will tell you it is, but confirm on the display on the centaur. If it reads "await connect" rather than "Connected" it is not connected. Disconnect in the DGT Chess app and then re-connect again.

Use the back arrow button (on the left of the buttons) to exit pegasus emulation mode.

I'll leave it here as a pull request for a little bit for any feedback.